### PR TITLE
ignore blacklist offenses in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ options:
       - '**/*_spec.rb'
   cancelled:
     case_sensitive: false
+    ignore_comments: false
 ```
 
 ### Options
@@ -46,6 +47,8 @@ options:
 `exclude`: Accepts an array of paths in .gitignore format. It will not blacklist the string in matching files.
 
 `case_sensitive`: Defaults to `true` if not set.
+
+`ignore_comments`: Defaults to `true` if not set.
 
 ## Development
 

--- a/lib/pronto/blacklist.rb
+++ b/lib/pronto/blacklist.rb
@@ -32,12 +32,19 @@ module Pronto
         return false if PathSpec.new(options['exclude']).match(line.patch.new_file_full_path)
       end
 
-
-      if options['case_sensitive'] == false
-        return line.content.downcase.include?(blacklist_string.downcase)
+      # if we should check comments for occurance of blacklisted string
+      if !evaluate_comments?(options)
+        return false if line.strip.start_with?("#")
       end
 
       line.content.include?(blacklist_string)
+    end
+
+    # should we check comments for occurances of blacklisted string?
+    def evaluate_comments?(options)
+      return false if options['ignore_comments'] == false
+      # default to true if the option isn't set
+      true
     end
 
     def new_message(line, word)

--- a/lib/pronto/blacklist.rb
+++ b/lib/pronto/blacklist.rb
@@ -37,6 +37,10 @@ module Pronto
         return false if line.strip.start_with?("#")
       end
 
+      if options['case_sensitive'] == false
+        return line.content.downcase.include?(blacklist_string.downcase)
+      end
+
       line.content.include?(blacklist_string)
     end
 


### PR DESCRIPTION
attempt to ignore blacklist offenses in comment strings, with an option to evaluate those comments if necessary.